### PR TITLE
make utf-8 export to file correctly

### DIFF
--- a/services/src/main/groovy/jd/gui/view/component/ClassFilePage.groovy
+++ b/services/src/main/groovy/jd/gui/view/component/ClassFilePage.groovy
@@ -156,7 +156,9 @@ class ClassFilePage
     }
 
     void save(API api, OutputStream os) {
-        os << textArea.text
+		OutputStreamWriter w = new OutputStreamWriter(os, "UTF-8");
+        w.write(textArea.text);
+		w.close();
     }
 
     // --- IndexesChangeListener --- //

--- a/services/src/main/java/jd/gui/service/sourcesaver/ClassFileSourceSaverProvider.java
+++ b/services/src/main/java/jd/gui/service/sourcesaver/ClassFileSourceSaverProvider.java
@@ -75,7 +75,7 @@ public class ClassFileSourceSaverProvider implements SourceSaver {
 
             // Init printer
             baos.reset();
-            PrintStream ps = new PrintStream(baos);
+            PrintStream ps = new PrintStream(baos,true,"UTF-8");
             printer.setPrintStream(ps);
             printer.setPreferences(preferences);
 


### PR DESCRIPTION
when saving files, utf-8 symbols were replaced with question marks('?'). now they're saved correctly