### PR TITLE
Fix build with Gradle 2.8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
 
     dependencies {
         classpath 'com.netflix.nebula:gradle-ospackage-plugin:2.2.6'
-        classpath 'org.spockframework:spock-core:1.0-groovy-2.3'
+        classpath 'org.spockframework:spock-core:1.0-groovy-2.4'
     }
 }
 


### PR DESCRIPTION
Currently, it does not build with Gradle 2.8 as one of the dependencies of jd-gui (Spock) depends on groovy 2.3.
