### PR TITLE
Adds support to open and save sources of 'aar' files.

### DIFF
--- a/api/src/main/java/org/jd/gui/api/feature/UriOpenable.java
+++ b/api/src/main/java/org/jd/gui/api/feature/UriOpenable.java
@@ -9,7 +9,7 @@ import java.net.URI;
 
 /**
  * uri                : scheme '://' path ('?' query)? ('#' fragment)?<br>
- * scheme             : 'generic' | 'jar' | 'war' | 'ear' | 'dex' | ...<br>
+ * scheme             : 'generic' | 'jar' | 'aar' | 'war' | 'ear' | 'dex' | ...<br>
  * path               : singlePath('!' singlePath)*<br>
  * singlePath         : [path/to/dir/] | [path/to/file]<br>
  * query              : queryLineNumber | queryPosition | querySearch<br>

--- a/services/src/main/groovy/org/jd/gui/service/fileloader/AarFileLoaderProvider.groovy
+++ b/services/src/main/groovy/org/jd/gui/service/fileloader/AarFileLoaderProvider.groovy
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2008-2015 Emmanuel Dupuy
+ * This program is made available under the terms of the GPLv3 License.
+ */
+
+package org.jd.gui.service.fileloader
+
+import org.jd.gui.api.API
+
+class AarFileLoaderProvider extends ZipFileLoaderProvider {
+
+	String[] getExtensions() { ['aar'] }
+	String getDescription() { 'Android archive files (*.aar)' }
+
+	boolean accept(API api, File file) {
+        return file.exists() && file.canRead() && file.name.toLowerCase().endsWith('.aar')
+	}
+}

--- a/services/src/main/groovy/org/jd/gui/service/sourcesaver/ZipFileSourceSaverProvider.groovy
+++ b/services/src/main/groovy/org/jd/gui/service/sourcesaver/ZipFileSourceSaverProvider.groovy
@@ -20,7 +20,7 @@ class ZipFileSourceSaverProvider extends DirectorySourceSaverProvider {
     /**
      * @return local + optional external selectors
      */
-    @Override String[] getSelectors() { ['*:file:*.zip', '*:file:*.jar', '*:file:*.war', '*:file:*.ear'] + externalSelectors }
+    @Override String[] getSelectors() { ['*:file:*.zip', '*:file:*.jar', '*:file:*.aar', '*:file:*.war', '*:file:*.ear'] + externalSelectors }
 
     @Override
     @CompileStatic

--- a/services/src/main/resources/META-INF/services/org.jd.gui.spi.FileLoader
+++ b/services/src/main/resources/META-INF/services/org.jd.gui.spi.FileLoader
@@ -1,3 +1,4 @@
+org.jd.gui.service.fileloader.AarFileLoaderProvider
 org.jd.gui.service.fileloader.ClassFileLoaderProvider
 org.jd.gui.service.fileloader.EarFileLoaderProvider
 org.jd.gui.service.fileloader.JarFileLoaderProvider

--- a/src/osx/resources/Info.plist
+++ b/src/osx/resources/Info.plist
@@ -52,6 +52,16 @@
 			<dict>
 				<key>CFBundleTypeExtensions</key>
 				<array>
+					<string>aar</string>
+				</array>
+				<key>CFBundleTypeName</key>			<string>Aar File</string>
+				<key>CFBundleTypeRole</key>			<string>Viewer</string>
+				<key>LSIsAppleDefaultForType</key>	<false/>
+				<key>LSTypeIsPackage</key>			<false/>
+			</dict>
+			<dict>
+				<key>CFBundleTypeExtensions</key>
+				<array>
 					<string>war</string>
 				</array>
 				<key>CFBundleTypeName</key>			<string>War File</string>


### PR DESCRIPTION
I was often renaming '.aar' files to '.jar' in order to open them with JD-GUI.
This pull requests adds support of this file format (http://tools.android.com/tech-docs/new-build-system/aar-format).

You can test this on Facebook SDK distribution '.aar' files: https://developers.facebook.com/docs/android/
- ./facebook/facebook-android-sdk-4.12.1.aar
- ./AccountKit/account-kit-sdk-4.12.1.aar
- ./AudienceNetwork/bin/AudienceNetwork.aar
- ./AudienceNetwork/bin/DebugSettings.aar

Thanks.
