### PR TITLE
Fix compilation error on openjdk 8

### DIFF
--- a/services/src/main/groovy/org/jd/gui/view/component/CustomLineNumbersPage.groovy
+++ b/services/src/main/groovy/org/jd/gui/view/component/CustomLineNumbersPage.groovy
@@ -54,9 +54,7 @@ abstract class CustomLineNumbersPage extends HyperlinkPage {
             if (lineNumberMap == null) {
                 lineNumberMap = new int[maxLineNumber * 3 / 2]
             } else if (lineNumberMap.length <= maxLineNumber) {
-                int[] tmp = new int[maxLineNumber * 3 / 2]
-                System.arraycopy(lineNumberMap, 0, tmp, 0, lineNumberMap.length)
-                lineNumberMap = tmp
+                lineNumberMap = Arrays.copyOf(lineNumberMap, lineNumberMap.length)
             }
 
             if (this.maxLineNumber < maxLineNumber) {

--- a/services/src/main/groovy/org/jd/gui/view/component/CustomLineNumbersPage.groovy
+++ b/services/src/main/groovy/org/jd/gui/view/component/CustomLineNumbersPage.groovy
@@ -54,7 +54,7 @@ abstract class CustomLineNumbersPage extends HyperlinkPage {
             if (lineNumberMap == null) {
                 lineNumberMap = new int[maxLineNumber * 3 / 2]
             } else if (lineNumberMap.length <= maxLineNumber) {
-                lineNumberMap = Arrays.copyOf(lineNumberMap, lineNumberMap.length)
+                lineNumberMap = Arrays.copyOf(lineNumberMap, maxLineNumber * 3 / 2)
             }
 
             if (this.maxLineNumber < maxLineNumber) {


### PR DESCRIPTION
On a basic gradle build of a fresh close on Ubuntu 16.04 with openjdk 8 installed, I got this compilation error.

Fix is to use the Arrays util instead of the direct system method, not sure why it broke, but the Arrays version is neater anyway.

```
:services:compileGroovy
startup failed:
/home/jammy/Applications/jd-gui/services/src/main/groovy/org/jd/gui/view/component/CustomLineNumbersPage.groovy: 58: Cannot call private method static java.lang.System#arraycopy from class org.jd.gui.view.component.CustomLineNumbersPage @ line 58, column 17.
                   System.arraycopy(lineNumberMap, 0, tmp, 0, lineNumberMap.length)
                   ^

1 error

:services:compileGroovy FAILED

FAILURE: Build failed with an exception.
```
