### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#JD-GUI
+# JD-GUI
 
 JD-GUI, a standalone graphical utility that displays Java sources from CLASS files.
 
@@ -8,12 +8,12 @@ JD-GUI, a standalone graphical utility that displays Java sources from CLASS fil
 - Java Decompiler Wikipedia page: [http://en.wikipedia.org/wiki/Java_Decompiler](http://en.wikipedia.org/wiki/Java_Decompiler)
 - JD-GUI source code: [https://github.com/java-decompiler/jd-gui](https://github.com/java-decompiler/jd-gui)
 
-##Description
+## Description
 JD-GUI is a standalone graphical utility that displays Java source codes of 
 ".class" files. You can browse the reconstructed source code with the JD-GUI
 for instant access to methods and fields.
 
-##How to build JD-GUI ?
+## How to build JD-GUI ?
 ```
 > ./gradlew build 
 ```
@@ -37,18 +37,18 @@ generate Ubuntu/Debian installer
 ```
 generate RedHat/CentOS/Fedora installer
 
-##How to launch JD-GUI ?
+## How to launch JD-GUI ?
 - Double-click on _"jd-gui-x.y.z.jar"_
 - Double-click on _"JD-GUI"_ application from Mac OSX
 - Double-click on _"jd-gui.exe"_ application from Windows
 - Execute _"java -jar jd-gui-x.y.z.jar"_ or _"java -classpath jd-gui-x.y.z.jar org.jd.gui.App"_
 
-##How to use JD-GUI ?
+## How to use JD-GUI ?
 - Open a file with menu "File > Open File..."
 - Open recent files with menu "File > Recent Files"
 - Drag and drop files from your file explorer
 
-##How to extend JD-GUI ?
+## How to extend JD-GUI ?
 ```
 > ./gradlew idea 
 ```
@@ -62,7 +62,7 @@ generate Eclipse project
 ```
 launch JD-GUI with your extensions
 
-##How to uninstall JD-GUI ?
+## How to uninstall JD-GUI ?
 - Java: Delete "jd-gui-x.y.z.jar" and "jd-gui.cfg".
 - Mac OSX: Drag and drop "JD-GUI" application into the trash.
 - Windows: Delete "jd-gui.exe" and "jd-gui.cfg".


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
