### PR TITLE
Add StartupWMClass to jd-gui.desktop for Linux

### DIFF
--- a/src/linux/resources/jd-gui.desktop
+++ b/src/linux/resources/jd-gui.desktop
@@ -6,3 +6,4 @@ Exec=java -jar /opt/jd-gui/jd-gui.jar
 Type=Application
 Icon=jd-gui
 MimeType=application/java;application/java-vm;application/java-archive
+StartupWMClass=org-jd-gui-App


### PR DESCRIPTION
This ensures that the application will appear under the correct icon if it is pinned to the taskbar.