### PR TITLE
Add OpenJDK11 compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -105,6 +105,7 @@ task proguard(type: proguard.gradle.ProGuardTask, dependsOn: 'jar') {
     injars jar.archivePath
     outjars 'build/libs/' + project.name + '-' + project.version + '-min.jar'
     libraryjars System.getProperty('java.home') + '/lib/rt.jar'
+    libraryjars System.getProperty('java.home') + '/jmods/'
 }
 
 // Java executable wrapper for Windows //

--- a/services/build.gradle
+++ b/services/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'java'
 
 dependencies {
-    compile 'com.fifesoft:rsyntaxtextarea:2.5.6'
+    compile 'com.fifesoft:rsyntaxtextarea:3.0.4'
     compile 'org.ow2.asm:asm:7.1'
     compile 'org.jd:jd-core:' + parent.jdCoreVersion
     compile project(':api')

--- a/services/src/main/java/org/jd/gui/view/component/TextPage.java
+++ b/services/src/main/java/org/jd/gui/view/component/TextPage.java
@@ -27,7 +27,7 @@ public class TextPage extends AbstractTextPage implements ContentCopyable, Conte
         if (textArea.getSelectionStart() == textArea.getSelectionEnd()) {
             getToolkit().getSystemClipboard().setContents(new StringSelection(""), null);
         } else {
-            textArea.copyAsRtf();
+            textArea.copyAsStyledText();
         }
     }
 


### PR DESCRIPTION
In order to make JD-GUI available via MacPorts, I've added OpenJDK11 support. In particular:

RSyntaxTextArea needs to be updated for JD-GUI to compile under OpenJDK11, which in turn requires TextPage.java to be patched. 

Proguard needs to search JAVA_HOME/jmods since JAVA_HOME/lib/rt.jar does not exist anymore with Java 9+