### PR TITLE
Fix links handling with tabs having empty paths

### DIFF
--- a/app/src/main/java/org/jd/gui/view/component/panel/TabbedPanel.java
+++ b/app/src/main/java/org/jd/gui/view/component/panel/TabbedPanel.java
@@ -131,7 +131,7 @@ public class TabbedPanel<T extends JComponent & UriGettable> extends JPanel impl
         while (i-- > 0) {
             T page = (T)tabbedPane.getComponentAt(i);
             String u2 = page.getUri().getPath();
-            if (u1.startsWith(u2)) {
+            if (!u2.isEmpty() && u1.startsWith(u2)) {
                 tabbedPane.setSelectedIndex(i);
                 return page;
             }


### PR DESCRIPTION
Proposed quick fix for https://github.com/java-decompiler/jd-gui/issues/277.
Ignore tabs with empty paths in TabbedPane.showPage(URI) method.