### PR TITLE
Update universalJavaApplicationStub to be able to launch on macOS Big Sur

### DIFF
--- a/src/osx/resources/universalJavaApplicationStub.sh
+++ b/src/osx/resources/universalJavaApplicationStub.sh
@@ -228,7 +228,7 @@ if [ -n "$JAVA_HOME" ] ; then
 # check for specified JVMversion in "/usr/libexec/java_home" symlinks
 elif [ ! -z ${JVMVersion} ] && [ -x /usr/libexec/java_home ] && /usr/libexec/java_home -F; then
 
-	if /usr/libexec/java_home -F -v ${JVMVersion}; then
+	if /usr/libexec/java_home -v ${JVMVersion} 2> /dev/null; then
 		JAVACMD="`/usr/libexec/java_home -F -v ${JVMVersion} 2> /dev/null`/bin/java"
 	else
 		# display error message with applescript


### PR DESCRIPTION
This change fixes a problem in `universalJavaApplicationStub.sh` that prevents JD-GUI.app from starting on my Mac (macOS Big Sur):

`/usr/libexec/java_home` does not support the combination of `-F` and `-v` if the version string contains a plus (as it does here since `$JVMVersion` is set to `1.8+` in Info.plist).

When this is called, the following error message appears:
_The operation couldn’t be completed. Unable to locate a Java Runtime that supports (null).
Please visit http://www.java.com for information on installing Java._

(there would be no error if `$JVMVersion` would be `1.8` for example)

On the other hand, you might as well want to merge PR #304 instead to update to the latest version of `universalJavaApplicationStub.sh` (version 3.0.6) where all of this has been rewritten so that the problem addressed by this change would not have occurred.
