### PR TITLE
Fixing application start up issue.

### DIFF
--- a/src/osx/resources/Info.plist
+++ b/src/osx/resources/Info.plist
@@ -146,7 +146,7 @@
 		<key>JavaX</key>
 		<dict>
 			<key>MainClass</key>					<string>org.jd.gui.OsxApp</string>
-			<key>JVMVersion</key>					<string>1.8+</string>
+			<key>JVMVersion</key>					<string>1.8</string>
 			<key>ClassPath</key>					<string>\$JAVAROOT/${JAR}</string>
 			<key>WorkingDirectory</key>				<string>\$JAVAROOT</string>
 			<key>Properties</key>


### PR DESCRIPTION
**Problem:**
```
ERROR launching JD-GUI
No suitable Java version found on your system!
This program requires Java 1.8+ 
Make sure you install the required Java version.
```

**Solution:**
I recently found that due to this '+' char at end in settings, application is not able to find Java 1.8 even it is present in Mac OS. As `java -verison` command out put is as below,
```
sarang@Sarangs-MacBook-Pro:~$ java -version
java version "1.8.0_261"
Java(TM) SE Runtime Environment (build 1.8.0_261-b12)
Java HotSpot(TM) 64-Bit Server VM (build 25.261-b12, mixed mode)
```