### PR TITLE
Fixed:JD-GUI not start on MaxOs Big Sur

### DIFF
--- a/src/osx/resources/universalJavaApplicationStub.sh
+++ b/src/osx/resources/universalJavaApplicationStub.sh
@@ -228,8 +228,8 @@ if [ -n "$JAVA_HOME" ] ; then
 # check for specified JVMversion in "/usr/libexec/java_home" symlinks
 elif [ ! -z ${JVMVersion} ] && [ -x /usr/libexec/java_home ] && /usr/libexec/java_home -F; then
 
-	if /usr/libexec/java_home -F -v ${JVMVersion}; then
-		JAVACMD="`/usr/libexec/java_home -F -v ${JVMVersion} 2> /dev/null`/bin/java"
+	if /usr/libexec/java_home -v ${JVMVersion}; then
+		JAVACMD="`/usr/libexec/java_home -v ${JVMVersion} 2> /dev/null`/bin/java"
 	else
 		# display error message with applescript
 		osascript -e "tell application \"System Events\" to display dialog \"ERROR launching '${CFBundleName}'\n\nNo suitable Java version found on your system!\nThis program requires Java ${JVMVersion}\nMake sure you install the required Java version.\" with title \"${CFBundleName}\" buttons {\" OK \"} default button 1 with icon path to resource \"${CFBundleIconFile}\" in bundle (path to me)"


### PR DESCRIPTION
When I tried to open the jd-gui in MacOS Big Sur, I reported the following error:

> ERROR launching 'JD-GUI'

> No suitable Java version found on your system!
> This program requires Java 1.8+
> Make sure you install the required Java version.

In the startup shell script `universalJavaApplicationStub.sh`, I print the log and find that `$Java_ Home` is `/bin/java`. Obviously, it lacks `BASE_PATH`, track the discovery of branches, and finally enter the following branches:

``` shell
elif [ ! -z ${JVMVersion} ] && [ -x /usr/libexec/java_home ] && /usr/libexec/java_home -F; then

	if /usr/libexec/java_home -F -v ${JVMVersion} 2> /dev/null; then
		JAVACMD="`/usr/libexec/java_home -F -v ${JVMVersion} 2> /dev/null`/bin/java"
	else
		# display error message with applescript
		osascript -e "tell application \"System Events\" to display dialog \"ERROR launching '${CFBundleName}'\n\nNo suitable Java version found on your system!\nThis program requires Java ${JVMVersion}\nMake sure you install the required Java version.\" with title \"${CFBundleName}\" buttons {\" OK \"} default button 1 with icon path to resource \"${CFBundleIconFile}\" in bundle (path to me)"
		# exit with error
		exit 3
	fi
elif ...

```

In this branch, I found that the execution result of command `/usr/libexec/java_home -F -v ${JVMVersion} 2> /dev/null` was empty, and the error was reported when executing on the command console:

java_home: option requires an argument -- v

Finally, I found that when the `v` option parameter of `java_home` command is string containing `+`, the combination option - F - V cannot be used together.

