### PR TITLE
Add a line to fix compat with macOS Big Sur

### DIFF
--- a/src/osx/resources/universalJavaApplicationStub.sh
+++ b/src/osx/resources/universalJavaApplicationStub.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+export JAVA_HOME=$(/usr/libexec/java_home -v11)
 ##################################################################################
 #                                                                                #
 # universalJavaApplicationStub                                                   #


### PR DESCRIPTION
Add `export JAVA_HOME=$(/usr/libexec/java_home -v11)` as a fix for everyone to https://github.com/java-decompiler/jd-gui/issues/332