### PR TITLE
macOS fix jvm version to retrieve jdk8

### DIFF
--- a/src/osx/resources/Info.plist
+++ b/src/osx/resources/Info.plist
@@ -146,7 +146,7 @@
 		<key>JavaX</key>
 		<dict>
 			<key>MainClass</key>					<string>org.jd.gui.OsxApp</string>
-			<key>JVMVersion</key>					<string>1.8+</string>
+			<key>JVMVersion</key>					<string>1.8</string>
 			<key>ClassPath</key>					<string>\$JAVAROOT/${JAR}</string>
 			<key>WorkingDirectory</key>				<string>\$JAVAROOT</string>
 			<key>Properties</key>


### PR DESCRIPTION
seems that 1.8+ does not match (at lest openjdk) new current distributions

```
➜  ~ /usr/libexec/java_home -v 1.8
/usr/local/Cellar/openjdk@8/1.8.0+282/libexec/openjdk.jdk/Contents/Home
➜  ~ /usr/libexec/java_home -v 1.8+
/usr/local/Cellar/openjdk/15.0.2/libexec/openjdk.jdk/Contents/Home
➜  ~
```