### PR TITLE
Upgrade the launch4j plugin to make the exe work with recent JRE

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.netflix.nebula:gradle-ospackage-plugin:5.3.0'    // RPM & DEB support
-        classpath 'edu.sc.seis.gradle:launch4j:2.4.4'
+        classpath 'edu.sc.seis.gradle:launch4j:3.0.4'
         classpath 'net.sf.proguard:proguard-gradle:6.1.0'
     }
 }
@@ -115,7 +115,7 @@ launch4j {
     version = textVersion = project.version
     fileDescription = productName = 'JD-GUI'
     errTitle 'JD-GUI Windows Wrapper'
-    copyright 'JD-GUI (C) 2008-2019 Emmanuel Dupuy'
+    copyright 'JD-GUI (C) 2008-2023 Emmanuel Dupuy'
     icon projectDir.path + '/src/launch4j/resources/images/jd-gui.ico'
     jar projectDir.path + '/' + proguard.outJarFiles[0]
     bundledJrePath = '%JAVA_HOME%'


### PR DESCRIPTION
Old versions of launch4j had an issue if JRE was patch > 100, we are today on 392. The bug was fixed in more recent version of the plugin.