### PR TITLE
Update MainClass in Info.plist (OSX)

### DIFF
--- a/src/osx/resources/Info.plist
+++ b/src/osx/resources/Info.plist
@@ -145,7 +145,7 @@
 		</array>
 		<key>JavaX</key>
 		<dict>
-			<key>MainClass</key>					<string>org.jd.gui.OsxApp</string>
+			<key>MainClass</key>					<string>org.jd.gui.App</string>
 			<key>JVMVersion</key>					<string>1.8+</string>
 			<key>ClassPath</key>					<string>\$JAVAROOT/${JAR}</string>
 			<key>WorkingDirectory</key>				<string>\$JAVAROOT</string>


### PR DESCRIPTION
According the the MANIFEST itself, the main class is: **org.jd.gui.App**

```
Manifest-Version: 1.0
JD-Core-Version: 1.1.3
JD-GUI-Version: 1.6.6
Main-Class: org.jd.gui.App
SplashScreen-Image: org/jd/gui/images/jd_icon_128.png
```

Launching with org.jd.gui.OsxApp triggers an exception.

```
Exception in thread "main" java.lang.IllegalAccessError: class org.jd.gui.OsxApp (in unnamed module @0x43556938) cannot access class com.apple.eawt.Application (in module java.desktop) because module java.desktop does not export com.apple.eawt to unnamed module @0x43556938
	at org.jd.gui.OsxApp.main(Unknown Source)
```