### PR TITLE
upgrade rsyntaxtextarea, then we can copy Unicode in decompiled file.

### DIFF
--- a/services/build.gradle
+++ b/services/build.gradle
@@ -1,7 +1,8 @@
 apply plugin: 'java'
 
 dependencies {
-    compile 'com.fifesoft:rsyntaxtextarea:3.0.4'
+//    compile 'com.fifesoft:rsyntaxtextarea:3.0.4'
+    compile 'com.fifesoft:rsyntaxtextarea:3.1.3'
     compile 'org.ow2.asm:asm:7.1'
     compile 'org.jd:jd-core:' + parent.jdCoreVersion
     compile project(':api')


### PR DESCRIPTION
upgrade rsyntaxtextarea, then we can copy Unicode in decompiled file.

When there are Unicod in java class files,  if we want  to copy that code which contain unicode escapse charaters (eg. Chinese), turns out that ,we can not copy them.

Test case is here:
[Welcome.zip](https://github.com/user-attachments/files/15598866/Welcome.zip)
