### PR TITLE
Update JAVACMD in universalJavaApplicationStub.sh

### DIFF
--- a/src/osx/resources/universalJavaApplicationStub.sh
+++ b/src/osx/resources/universalJavaApplicationStub.sh
@@ -220,9 +220,15 @@ fi
 #
 # find installed Java versions
 #################################
-
-# first check system variable "$JAVA_HOME"
-if [ -n "$JAVA_HOME" ] ; then
+# As Java 1.8 is old and no more supported, 
+# running this up on new new Java versions doesn't work 
+# and force the user to install Java 8 which override the existing new Java
+# first check system variable "$JAVA_HOME_V8".
+if [ -n "$JAVA_HOME_V8" ] ; then
+	JAVACMD="$JAVA_HOME_V8/bin/java"
+ 
+# check standard system variable "$JAVA_HOME"
+elif [ -n "$JAVA_HOME" ] ; then
 	JAVACMD="$JAVA_HOME/bin/java"
 	
 # check for specified JVMversion in "/usr/libexec/java_home" symlinks


### PR DESCRIPTION
### Proposal to make it easy to run this application on new machines without installing java 1.8 globally:

As Java 1.8 is old and no more supported, running this up on new new Java versions doesn't work. 

To fix the issue the user is forced to install (zip) Java 8 which override the existing new Java. With this new ENV var, we can install Java 1.8 in a dedicated folder without polluting our JAVA_HOME or our PATH.
Then add a new environment variable **JAVA_HOME_V8** that point to the Java 1.8 home.